### PR TITLE
HYDRAN-2040 Temporary adjustment for EDPFuture logic

### DIFF
--- a/src/main/java/se/sundsvall/casemanagement/integration/edpfuture/EDPFutureService.java
+++ b/src/main/java/se/sundsvall/casemanagement/integration/edpfuture/EDPFutureService.java
@@ -62,27 +62,44 @@ public class EDPFutureService {
 		var request = createGetAuthorizedUsersRequest(identityNumber);
 		var response = edpFutureClient.getAuthorizedUsers(request);
 
-		return getCustomerId(response);
+		return getCustomerIdTemporary(response);
 	}
 
 	/**
-	 * Extracts the customerId from the GetAuthorizedUsersResponse. It looks for an authorized user that has an approved
-	 * eService of type "Order" and returns the associated customerId.
-	 *
-	 * @param  response GetAuthorizedUsersResponse containing the list of authorized users and their approved eServices.
-	 * @return          customerId for given identity number that has an approved eService of type "Order".
+	 * TEMPORARY: Returns the customerId of the first authorized user without filtering on approved eService type "Order".
+	 * EDP Future is not currently returning "Order" in the eService list even though it should be present. Restore the
+	 * commented-out {@code getCustomerId(GetAuthorizedUsersResponse)} below once the upstream issue has been resolved.
 	 */
-	private int getCustomerId(final GetAuthorizedUsersResponse response) {
+	private int getCustomerIdTemporary(final GetAuthorizedUsersResponse response) {
 		var users = response.getGetAuthorizedUsersResult().getResultValue().getAuthorizedUser();
 		var user = users.stream()
-			.filter(authorizedUser -> authorizedUser.getApprovedEservices().getEServiceType().stream()
-				.anyMatch(service -> "Order".equals(service.value())))
 			.findFirst()
 			.orElseThrow(() -> Problem.valueOf(BAD_GATEWAY,
-				"Failed to retrieve customerId from EDP Future. No approved eService of type 'Order' found for the given identity number."));
+				"Failed to retrieve customerId from EDP Future. No authorized users found."));
 
 		return user.getCustomerId();
 	}
+
+	// TODO: Re-enable this method (and remove getCustomerIdTemporary) once EDP Future returns "Order" in the eService list.
+	// /**
+	// * Extracts the customerId from the GetAuthorizedUsersResponse. It looks for an authorized user that has an approved
+	// * eService of type "Order" and returns the associated customerId.
+	// *
+	// * @param response GetAuthorizedUsersResponse containing the list of authorized users and their approved eServices.
+	// * @return customerId for given identity number that has an approved eService of type "Order".
+	// */
+	// private int getCustomerId(final GetAuthorizedUsersResponse response) {
+	// var users = response.getGetAuthorizedUsersResult().getResultValue().getAuthorizedUser();
+	// var user = users.stream()
+	// .filter(authorizedUser -> authorizedUser.getApprovedEservices().getEServiceType().stream()
+	// .anyMatch(service -> "Order".equals(service.value())))
+	// .findFirst()
+	// .orElseThrow(() -> Problem.valueOf(BAD_GATEWAY,
+	// "Failed to retrieve customerId from EDP Future. No approved eService of type 'Order' found for the given identity
+	// number."));
+	//
+	// return user.getCustomerId();
+	// }
 
 	private GetAuthorizedUsers createGetAuthorizedUsersRequest(final String identityNumber) {
 		var request = new GetAuthorizedUsers();

--- a/src/test/java/se/sundsvall/casemanagement/integration/edpfuture/EDPFutureServiceTest.java
+++ b/src/test/java/se/sundsvall/casemanagement/integration/edpfuture/EDPFutureServiceTest.java
@@ -132,18 +132,34 @@ class EDPFutureServiceTest {
 	}
 
 	@Test
-	void getCustomerIdNoOrderEService() {
+	void getCustomerIdNoAuthorizedUsers() {
 		when(edpFutureClientMock.getAuthorizedUsers(any()))
-			.thenReturn(createGetAuthorizedUsersResponse(EServiceType.MY_SERVICES));
+			.thenReturn(createEmptyGetAuthorizedUsersResponse());
 
 		assertThatThrownBy(() -> edpFutureService.getCustomerId(IDENTITY_NUMBER))
 			.isInstanceOf(Problem.class)
 			.hasMessageContaining(BAD_GATEWAY.getReasonPhrase())
-			.hasMessageContaining("No approved eService of type 'Order' found");
+			.hasMessageContaining("No authorized users found");
 
 		verify(edpFutureClientMock).getAuthorizedUsers(any());
 		verifyNoMoreInteractions(edpFutureClientMock);
 	}
+
+	// TODO: Re-enable this test (and remove getCustomerIdNoAuthorizedUsers) once EDP Future returns "Order" in the eService
+	// list.
+	// @Test
+	// void getCustomerIdNoOrderEService() {
+	// when(edpFutureClientMock.getAuthorizedUsers(any()))
+	// .thenReturn(createGetAuthorizedUsersResponse(EServiceType.MY_SERVICES));
+	//
+	// assertThatThrownBy(() -> edpFutureService.getCustomerId(IDENTITY_NUMBER))
+	// .isInstanceOf(Problem.class)
+	// .hasMessageContaining(BAD_GATEWAY.getReasonPhrase())
+	// .hasMessageContaining("No approved eService of type 'Order' found");
+	//
+	// verify(edpFutureClientMock).getAuthorizedUsers(any());
+	// verifyNoMoreInteractions(edpFutureClientMock);
+	// }
 
 	@Test
 	void getBuildingId() {
@@ -294,6 +310,13 @@ class EDPFutureServiceTest {
 			.withGetAuthorizedUsersResult(
 				new OperationResultOfArrayOfAuthorizedUserFbShh6Ke()
 					.withResultValue(new ArrayOfAuthorizedUser().withAuthorizedUser(user)));
+	}
+
+	private GetAuthorizedUsersResponse createEmptyGetAuthorizedUsersResponse() {
+		return new GetAuthorizedUsersResponse()
+			.withGetAuthorizedUsersResult(
+				new OperationResultOfArrayOfAuthorizedUserFbShh6Ke()
+					.withResultValue(new ArrayOfAuthorizedUser()));
 	}
 
 	private GetBuildingsByAutorizationRoleV12Response createGetBuildingsResponse(final String address) {


### PR DESCRIPTION
* Temporary fix for testing seperate parts of the EDPFuture logic. The previous solution is still how we want the system to work, but while external parties troubleshoot EDPFuture we proceed with this temporary fix.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
